### PR TITLE
Upgrade Gem module, and fix bug of ttml2srt

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,7 +3,6 @@
 .bundle
 .config
 .yardoc
-Gemfile.lock
 InstalledFiles
 _yardoc
 coverage

--- a/Gemfile
+++ b/Gemfile
@@ -2,3 +2,8 @@ source 'https://rubygems.org'
 
 # Specify your gem's dependencies in ttml.gemspec
 gemspec
+
+group :development do
+  gem "rake", "13.0.6"
+  gem "test-unit", "3.5.7"
+end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,0 +1,31 @@
+PATH
+  remote: .
+  specs:
+    ttml-ruby (0.5.0)
+      nokogiri (= 1.14.1)
+      optimist (= 3.0.1)
+
+GEM
+  remote: https://rubygems.org/
+  specs:
+    mini_portile2 (2.8.1)
+    nokogiri (1.14.1)
+      mini_portile2 (~> 2.8.0)
+      racc (~> 1.4)
+    optimist (3.0.1)
+    power_assert (2.0.3)
+    racc (1.6.2)
+    rake (13.0.6)
+    test-unit (3.5.7)
+      power_assert
+
+PLATFORMS
+  ruby
+
+DEPENDENCIES
+  rake (= 13.0.6)
+  test-unit (= 3.5.7)
+  ttml-ruby!
+
+BUNDLED WITH
+   2.1.4

--- a/bin/ttml2srt
+++ b/bin/ttml2srt
@@ -1,9 +1,9 @@
 #!/usr/bin/env ruby
 require 'rubygems'
 require 'ttml'
-require 'trollop'
+require 'optimist'
 
-opts = Trollop::options do
+opts = Optimist::options do
   opt :offset, "Offset in seconds to apply when converting", :default => 0
   banner <<EOS
 This script converts a ttml xml file containing subtitles to a SubRip format
@@ -20,11 +20,11 @@ def self.conv2srt fname, offset
   counter = 1
   doc.subtitle_stream.each do |sub|
     # Avoid outputting empty lines
-    cleaned = TTML::Util.clean_tags(sub.content)
+    cleaned = TTML::Util.strip_tags(sub.content)
     next if cleaned.empty?
     b_time = sub['begin'].to_i + offset
     e_time = sub['end'].to_i + offset
-    print "#{ counter }\n#{ TTML::Util.smpte_time(b_time) } --> #{ Ttml::Util.smpte_time(e_time) }\n#{ cleaned }\n\n"
+    print "#{ counter }\n#{ TTML::Util.smpte_time(b_time) } --> #{ TTML::Util.smpte_time(e_time) }\n#{ cleaned }\n\n"
     counter += 1
   end
 end

--- a/ttml-ruby.gemspec
+++ b/ttml-ruby.gemspec
@@ -15,6 +15,6 @@ Gem::Specification.new do |gem|
   gem.require_paths = ["lib"]
   gem.version       = TTML::VERSION
 
-  gem.add_runtime_dependency "nokogiri"
-  gem.add_runtime_dependency "trollop"
+  gem.add_runtime_dependency "nokogiri", "1.14.1"
+  gem.add_runtime_dependency "optimist", "3.0.1"
 end


### PR DESCRIPTION
* trollop was renamed to optimist, so modified to use optimist
* `ttml2srt` does not work, modified to work.
* added `rake` and `test-unit` to `Gemfile` since they are not in development dependencies and can't be tested
* Added `Gemfile.lock` to lock the version.